### PR TITLE
Add agent post-commit GitHub comment functionality

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -194,5 +194,8 @@ jobs:
             -e GITHUB_REF="${{ steps.context.outputs.REF }}" \
             -e CLAUDE_BRANCH_NAME="claude-${{ steps.context.outputs.CLAUDE_TYPE }}-${{ steps.context.outputs.CLAUDE_NUMBER }}" \
             -e USER_PROMPT="$USER_PROMPT" \
+            -e GITHUB_ACTOR="${{ steps.context.outputs.ACTOR }}" \
+            -e ISSUE_TYPE="${{ steps.context.outputs.TYPE }}" \
+            -e ISSUE_NUMBER="${{ steps.context.outputs.NUMBER }}" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             sdlc-claude:latest


### PR DESCRIPTION
## Summary

This PR restores the functionality to post Claude Code's response as a GitHub comment after execution completes, as requested in issue #22.

## Changes Made

- **Updated `entrypoint.sh`**: Added logic to post Claude's output as a comment on the issue/PR using the GitHub API
  - Uses `jq` to format the comment body with proper JSON escaping
  - Posts comment after Claude execution but before final state commit
  - Includes error handling for empty output
  
- **Updated `claude.yml` workflow**: Added three new environment variables to the Docker container:
  - `GITHUB_ACTOR` - The user who triggered the workflow
  - `ISSUE_TYPE` - Whether it's an "issue" or "pr"
  - `ISSUE_NUMBER` - The issue or PR number

## How It Works

1. After Claude Code completes execution, the output is captured in `/tmp/claude-output.txt`
2. The script uses `jq` to format a JSON payload with the output and metadata
3. A POST request is made to GitHub's API to create a comment on the issue/PR
4. The comment includes:
   - Claude's full response
   - Attribution showing who triggered it and on which issue/PR

## Testing

This functionality can be tested by:
1. Merging this PR
2. Triggering the Claude workflow on an issue or PR
3. Verifying that a comment is posted with Claude's response

## Related Issue

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)