### PR TITLE
Add GLM 4.6 Support (Experimental)

### DIFF
--- a/.github/sdlc/claude-code-runner/entrypoint.sh
+++ b/.github/sdlc/claude-code-runner/entrypoint.sh
@@ -110,6 +110,45 @@ fi
 echo "Repository cloned to: $WORKSPACE_DIR"
 echo ""
 
+# Configure GLM if enabled
+if [ "${USE_GLM:-false}" = "true" ]; then
+    echo "=== Configuring GLM 4.6 Support ==="
+    if [ -z "$ZAI_API_KEY" ]; then
+        echo "ERROR: USE_GLM is true but ZAI_API_KEY is not set"
+        exit 1
+    fi
+
+    echo "Configuring Claude Code to use Z.AI's GLM models..."
+
+    # Create or update ~/.claude/settings.json with GLM configuration
+    mkdir -p /home/claude/.claude
+
+    cat > /home/claude/.claude/settings.json << 'EOF'
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "ZAI_API_KEY_PLACEHOLDER",
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "API_TIMEOUT_MS": "3000000",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.5-air",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-4.6"
+  }
+}
+EOF
+
+    # Replace the placeholder with the actual API key
+    sed -i "s/ZAI_API_KEY_PLACEHOLDER/$ZAI_API_KEY/g" /home/claude/.claude/settings.json
+
+    echo "GLM 4.6 configuration complete"
+    echo "  - Using Z.AI endpoint: https://api.z.ai/api/anthropic"
+    echo "  - Model mapping: Sonnet/Opus -> GLM-4.6, Haiku -> GLM-4.5-Air"
+    echo ""
+else
+    echo "=== Using Standard Claude Code (Anthropic) ==="
+    echo "GLM support is disabled. Using CLAUDE_CODE_OAUTH_TOKEN for authentication."
+    echo ""
+fi
+
 # Prepare prompts
 echo "=== Preparing prompts ==="
 

--- a/.github/sdlc/github-runner/docker-compose.yml
+++ b/.github/sdlc/github-runner/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
       - RUNNER_SCOPE=${RUNNER_SCOPE:-repo}
       - RUNNER_PREFIX=${RUNNER_PREFIX:-}
+      - USE_GLM=${USE_GLM:-false}
+      - ZAI_API_KEY=${ZAI_API_KEY:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     deploy:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -199,5 +199,7 @@ jobs:
             -e GITHUB_ACTOR="${{ steps.context.outputs.ACTOR }}" \
             -e ISSUE_TYPE="${{ steps.context.outputs.TYPE }}" \
             -e ISSUE_NUMBER="${{ steps.context.outputs.NUMBER }}" \
+            -e USE_GLM="${USE_GLM:-false}" \
+            -e ZAI_API_KEY="${ZAI_API_KEY:-}" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             sdlc-claude:latest

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ ZAI_API_KEY=
 
 SDLC now supports using Z.AI's GLM 4.6 models as an experimental alternative to Anthropic's Claude models. This feature allows you to:
 
-- Use GLM-4.6 for high-quality code generation (maps to Sonnet and Opus)
-- Use GLM-4.5-Air for faster responses (maps to Haiku)
+- Use GLM-4.6 for high-quality code generation (replaces both Sonnet and Opus; both are mapped to the same GLM-4.6 model variant)
+- Use GLM-4.5-Air for faster responses (replaces Haiku)
 - Connect to Z.AI's API endpoint as a drop-in replacement
 
 ### Setting Up GLM 4.6

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ A self-hosted GitHub Actions infrastructure that integrates Claude Code AI assis
 - **Scalable**: Configure multiple parallel runners for concurrent tasks
 - **Secure**: Uses GitHub Personal Access Tokens with proper scopes
 - **Flexible**: Works with both repository-level and organization-level runners
+- **GLM 4.6 Support (Experimental)**: Option to use Z.AI's GLM models as a drop-in replacement
 
 ## Prerequisites
 
 - Docker (v20.10 or later)
 - docker-compose (v1.29 or later)
 - GitHub repository with admin access
-- Claude Code OAuth token
+- **Either:**
+  - Claude Code OAuth token (for standard Anthropic Claude), OR
+  - Z.AI API key (for experimental GLM 4.6 support)
 - GitHub Personal Access Token with appropriate scopes:
   - For repository runners: `repo` (Full control of private repositories)
   - For organization runners: `admin:org` (Full control of orgs and teams)
@@ -143,7 +146,58 @@ RUNNER_PREFIX=my-hostname
 
 # Number of parallel runners
 RUNNER_REPLICATIONS=5
+
+# GLM 4.6 Support (Experimental)
+USE_GLM=false
+ZAI_API_KEY=
 ```
+
+## GLM 4.6 Support (Experimental)
+
+SDLC now supports using Z.AI's GLM 4.6 models as an experimental alternative to Anthropic's Claude models. This feature allows you to:
+
+- Use GLM-4.6 for high-quality code generation (maps to Sonnet and Opus)
+- Use GLM-4.5-Air for faster responses (maps to Haiku)
+- Connect to Z.AI's API endpoint as a drop-in replacement
+
+### Setting Up GLM 4.6
+
+1. **Get a Z.AI API Key**:
+   - Visit [Z.AI Open Platform](https://z.ai/model-api)
+   - Register or login to your account
+   - Create an API key in the [API Keys management page](https://z.ai/manage-apikey/apikey-list)
+   - Copy your API key for use in setup
+
+2. **Configure During Setup**:
+   When running `./sdlc.sh --setup`, answer "yes" when prompted about GLM 4.6 support and provide your Z.AI API key.
+
+3. **Manual Configuration**:
+   Alternatively, edit `.github/sdlc/github-runner/.env` and set:
+   ```env
+   USE_GLM=true
+   ZAI_API_KEY=your_zai_api_key_here
+   ```
+
+4. **GitHub Secrets**:
+   - When using GLM, you still need to set `CLAUDE_CODE_OAUTH_TOKEN` in GitHub Secrets
+   - The system will use the Z.AI API key for model access instead
+
+### Model Mapping
+
+When GLM support is enabled, Claude Code's model selection maps to:
+
+| Claude Code Model | GLM Model      | Use Case               |
+|-------------------|----------------|------------------------|
+| Opus              | GLM-4.6        | Complex tasks          |
+| Sonnet            | GLM-4.6        | Balanced performance   |
+| Haiku             | GLM-4.5-Air    | Fast responses         |
+
+### Important Notes
+
+- This is an **experimental feature** - behavior may differ from standard Claude
+- API timeout is set to 3000 seconds (50 minutes) for long-running tasks
+- The Z.AI endpoint (`https://api.z.ai/api/anthropic`) provides Anthropic-compatible API
+- You can switch back to standard Claude by setting `USE_GLM=false` in the `.env` file
 
 ## Project Structure
 

--- a/sdlc.sh
+++ b/sdlc.sh
@@ -237,6 +237,39 @@ run_setup() {
         done
 
         echo ""
+
+        # Prompt for GLM support (optional)
+        echo -e "${YELLOW}5. GLM 4.6 Support (Experimental)${NC}"
+        echo "   Would you like to use GLM 4.6 from Z.AI instead of Claude?"
+        echo "   This is an experimental feature that uses Z.AI's API as a drop-in replacement."
+        echo "   You'll need a Z.AI API key from: https://z.ai/model-api"
+        echo ""
+        read -p "   Enable GLM 4.6 support? (y/n, default: n): " ENABLE_GLM
+
+        USE_GLM="false"
+        ZAI_API_KEY=""
+
+        if [[ $ENABLE_GLM =~ ^[Yy]$ ]]; then
+            USE_GLM="true"
+            echo ""
+            echo -e "${BLUE}   GLM 4.6 Configuration${NC}"
+            echo "   Create an API key at: https://z.ai/manage-apikey/apikey-list"
+            echo ""
+
+            while true; do
+                read -s -p "   Enter your Z.AI API key: " ZAI_API_KEY
+                echo ""
+
+                validate_non_empty "$ZAI_API_KEY" "Z.AI API key" || continue
+                break
+            done
+
+            echo -e "${GREEN}   ✓ GLM 4.6 support enabled${NC}"
+        else
+            echo -e "${BLUE}   ✓ Using standard Claude Code (Anthropic)${NC}"
+        fi
+
+        echo ""
         echo -e "${BLUE}Creating .env file...${NC}"
 
         # Create .env file with provided values
@@ -259,6 +292,12 @@ RUNNER_PREFIX=$RUNNER_PREFIX
 
 # Number of runner replications (default: 5)
 RUNNER_REPLICATIONS=$RUNNER_REPLICATIONS
+
+# GLM 4.6 Support (Experimental) - Set to 'true' to use Z.AI's GLM models
+USE_GLM=$USE_GLM
+
+# Z.AI API Key (required if USE_GLM=true)
+ZAI_API_KEY=$ZAI_API_KEY
 EOF
 
         echo -e "${GREEN}✓ Created .env file with your configuration${NC}"


### PR DESCRIPTION
## Summary

This PR implements Z.AI's GLM 4.6 models as an experimental alternative to Anthropic's Claude models for the SDLC system, as requested in #28.

### What's New

✨ **GLM 4.6 Integration**:
- Added optional configuration during `./sdlc.sh --setup` to enable GLM support
- Automatic configuration of Claude Code to use Z.AI's API endpoint
- Model mapping: GLM-4.6 (Opus/Sonnet) and GLM-4.5-Air (Haiku)

### Changes Made

- **sdlc.sh**: Added interactive prompts for GLM configuration during setup
- **entrypoint.sh**: Configures `~/.claude/settings.json` with GLM settings when enabled
- **docker-compose.yml**: Passes GLM environment variables to containers
- **claude.yml**: Updated GitHub Actions workflow to include GLM configuration
- **README.md**: Added comprehensive documentation for GLM 4.6 setup and usage

### Configuration

Users can enable GLM during setup by:
1. Running `./sdlc.sh --setup`
2. Answering "yes" to GLM 4.6 support
3. Providing their Z.AI API key

Or manually editing `.github/sdlc/github-runner/.env`:
```env
USE_GLM=true
ZAI_API_KEY=your_api_key_here
```

### Model Mapping

| Claude Code Model | GLM Model      | Use Case               |
|-------------------|----------------|------------------------|
| Opus              | GLM-4.6        | Complex tasks          |
| Sonnet            | GLM-4.6        | Balanced performance   |
| Haiku             | GLM-4.5-Air    | Fast responses         |

## Test Plan

- [x] Bash syntax validation passed for all scripts
- [x] Git commit created successfully
- [ ] Manual testing: Run setup with GLM enabled
- [ ] Manual testing: Verify Claude Code connects to Z.AI endpoint
- [ ] Manual testing: Test issue comment with @claude mention

## Notes

- This is marked as **experimental** - users should be aware behavior may differ from standard Claude
- API timeout set to 3000 seconds (50 minutes) for long-running tasks
- Users can switch back to standard Claude by setting `USE_GLM=false`

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)